### PR TITLE
reside-124: Error if download is not successful

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^\.lintr$
+^Makefile$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+PACKAGE := $(shell grep '^Package:' DESCRIPTION | sed -E 's/^Package:[[:space:]]+//')
+RSCRIPT = Rscript --no-init-file
+
+all: install
+
+test:
+	${RSCRIPT} -e 'library(methods); devtools::test()'
+
+test_all:
+	REMAKE_TEST_INSTALL_PACKAGES=true make test
+
+roxygen:
+	@mkdir -p man
+	${RSCRIPT} -e "library(methods); devtools::document()"
+
+install:
+	R CMD INSTALL .
+
+build:
+	R CMD build .
+
+check:
+	_R_CHECK_CRAN_INCOMING_=FALSE make check_all
+
+check_all:
+	${RSCRIPT} -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual'))"
+
+README.md: README.Rmd
+	Rscript -e "options(warnPartialMatchArgs=FALSE); knitr::knit('$<')"
+	sed -i.bak 's/[[:space:]]*$$//' README.md
+	rm -f $@.bak myfile.json
+
+
+pkgdown:
+	${RSCRIPT} -e "library(methods); pkgdown::build_site()"
+
+website: pkgdown
+	./scripts/update_web.sh
+
+js/bundle.js: js/package.json js/in.js
+	./js/build
+
+inst/js/bundle.js: js/bundle.js
+	mkdir -p inst/js
+	cp $< $@
+	cp js/node_modules/i18next/LICENSE inst/js/LICENSE.i18next
+
+vignettes: vignettes/traduire.Rmd
+	${RSCRIPT} -e 'tools::buildVignettes(dir = ".")'
+	mkdir -p inst/doc
+	cp vignettes/*.html vignettes/*.Rmd inst/doc
+
+.PHONY: all test document install vignettes

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -35,5 +35,5 @@ get_single_credential <- function(env_var, credential, read_func) {
 
 ## This exists just so we can mock it in tests as you can't mock base functions
 is_interactive <- function() {
-  interactive()
+  interactive() # nocov
 }

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -55,6 +55,11 @@ pointr <- R6::R6Class(
       res <- private$client$GET(URLencode(sharepoint_path),
                                 opts,
                                 httr::write_disk(save_path))
+      if (httr::status_code(res) == 404) {
+        unlink(save_path)
+        stop(sprintf("Remote file not found at '%s'", sharepoint_path))
+      }
+      httr::stop_for_status(res)
       save_path
     }
   ),

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -48,7 +48,7 @@ pointr <- R6::R6Class(
     #' @return Path to saved data
     download = function(sharepoint_path, save_path, verbose = FALSE) {
       if (verbose) {
-        opts <- httr::verbose()
+        opts <- httr::progress()
       } else {
         opts <- NULL
       }

--- a/tests/testthat/helper-sharepoint-client.R
+++ b/tests/testthat/helper-sharepoint-client.R
@@ -16,3 +16,10 @@ mock_sharepoint_client <- function(sharepoint_url) {
   )
   client
 }
+
+
+mock_response <- function(status_code = 200L) {
+  structure(
+    list(status_code = status_code),
+    class = "response")
+}

--- a/tests/testthat/test-pointr.R
+++ b/tests/testthat/test-pointr.R
@@ -66,7 +66,7 @@ test_that("httr download can print verbose output", {
   expect_equal(mockery::mock_args(mock_get)[[1]][[1]],
                "https://httpbin.org/anything/any%20thing")
   expect_equal(mockery::mock_args(mock_get)[[1]][[2]],
-               httr::verbose())
+               httr::progress())
 })
 
 test_that("sharepoint_download errors on 404", {

--- a/tests/testthat/test-pointr.R
+++ b/tests/testthat/test-pointr.R
@@ -27,7 +27,7 @@ test_that("download encodes URL", {
   cookies_res <- readRDS("mocks/cookies_response.rds")
   mock_post <- mockery::mock(security_token_res, cookies_res)
 
-  mock_get <- mockery::mock("response")
+  mock_get <- mockery::mock(mock_response())
 
   t <- tempfile()
   withr::with_envvar(
@@ -50,7 +50,7 @@ test_that("httr download can print verbose output", {
   cookies_res <- readRDS("mocks/cookies_response.rds")
   mock_post <- mockery::mock(security_token_res, cookies_res)
 
-  mock_get <- mockery::mock("response")
+  mock_get <- mockery::mock(mock_response())
 
   t <- tempfile()
   withr::with_envvar(


### PR DESCRIPTION
Looks like we can just check the http status code, I had to tweak the mocks slightly to add a response object there.

I've also changed `httr::verbose` to `httr::progress` on the download - the former is not designed for users, and can always be turned on with `httr::with_progress`