### PR TITLE
reside-125: Get credentials even in a noninteractive session

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -10,15 +10,16 @@ get_credentials <- function() {
   list(
     username = get_single_credential("SHAREPOINT_USERNAME",
                                      "Sharepoint username",
-                                     read_line),
-    password = get_single_credential("SHAREPOINT_PASS", "Sharepoint password",
+                                     get_string),
+    password = get_single_credential("SHAREPOINT_PASS",
+                                     "Sharepoint password",
                                      get_pass)
   )
 }
 
 get_single_credential <- function(env_var, credential, read_func) {
   cred <- Sys.getenv(env_var)
-  if (is_empty(cred) && is_interactive()) {
+  if (is_empty(cred)) {
     cred <- read_func(paste0(credential, ": "))
   }
   tryCatch(
@@ -26,14 +27,9 @@ get_single_credential <- function(env_var, credential, read_func) {
     error = function(e) {
       e$message <- paste0(
         e$message,
-        sprintf(", either set env var %s or enter in interactive session",
+        sprintf(", either set env var %s or enter at prompt",
                 env_var))
       stop(e)
     })
   cred
-}
-
-## This exists just so we can mock it in tests as you can't mock base functions
-is_interactive <- function() {
-  interactive() # nocov
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,8 +7,14 @@ get_pass <- function(prompt) {
 }
 
 get_string <- function(prompt) {
-  message(prompt, appendLF = FALSE) # nocov
-  clean_input_text(scan("stdin", character(), n = 1, quiet = TRUE)) # nocov
+  # nocov start
+  if (interactive()) {
+    clean_input_text(readline(prompt))
+  } else {
+    message(prompt, appendLF = FALSE)
+    clean_input_text(scan("stdin", character(), n = 1, quiet = TRUE))
+  }
+  # nocov end
 }
 
 clean_input_text <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,8 +7,8 @@ get_pass <- function(prompt) {
 }
 
 get_string <- function(prompt) {
-  message(prompt, appendLF = FALSE)
-  clean_input_text(scan("stdin", character(), n = 1, quiet = TRUE))
+  message(prompt, appendLF = FALSE) # nocov
+  clean_input_text(scan("stdin", character(), n = 1, quiet = TRUE)) # nocov
 }
 
 clean_input_text <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,8 +6,9 @@ get_pass <- function(prompt) {
   getPass::getPass(prompt, TRUE) # nocov
 }
 
-read_line <- function(prompt) {
-  clean_input_text(readline(prompt = prompt)) # nocov
+get_string <- function(prompt) {
+  message(prompt, appendLF = FALSE)
+  clean_input_text(scan("stdin", character(), n = 1, quiet = TRUE))
 }
 
 clean_input_text <- function(x) {

--- a/tests/testthat/test-credentials.R
+++ b/tests/testthat/test-credentials.R
@@ -2,14 +2,10 @@ context("credentials")
 
 test_that("can get user auth credentials", {
   mock_read_cred <- mockery::mock("mock_cred", cycle = TRUE)
-  ## Mock interactive to default true so we can test this behaviour during tests
-  mock_interactive <- mockery::mock(TRUE, cycle = TRUE)
-
   withr::with_envvar(
     c("SHAREPOINT_USERNAME" = NA, "SHAREPOINT_PASS" = NA),
     with_mock("getPass::getPass" = mock_read_cred,
-              "pointr:::read_line" = mock_read_cred,
-              "pointr:::is_interactive" = mock_interactive, {
+              "pointr:::get_string" = mock_read_cred, {
       creds <- get_credentials()
     })
   )
@@ -19,8 +15,7 @@ test_that("can get user auth credentials", {
   withr::with_envvar(
     c("SHAREPOINT_USERNAME" = "user", "SHAREPOINT_PASS" = NA),
     with_mock("getPass::getPass" = mock_read_cred,
-              "pointr:::read_line" = mock_read_cred,
-              "pointr:::is_interactive" = mock_interactive, {
+              "pointr:::get_string" = mock_read_cred, {
       creds <- get_credentials()
     })
   )
@@ -30,8 +25,7 @@ test_that("can get user auth credentials", {
   withr::with_envvar(
     c("SHAREPOINT_USERNAME" = "user", "SHAREPOINT_PASS" = "pass"),
     with_mock("getPass::getPass" = mock_read_cred,
-              "pointr:::read_line" = mock_read_cred,
-              "pointr:::is_interactive" = mock_interactive, {
+              "pointr:::get_string" = mock_read_cred, {
       creds <- get_credentials()
     })
   )
@@ -42,14 +36,10 @@ test_that("can get user auth credentials", {
 test_that("error thrown if no credential entered by user", {
   read_cred <- function(msg) NA
   ## Mock interactive to default true so we can test this behaviour during tests
-  mock_interactive <- mockery::mock(TRUE, cycle = TRUE)
   withr::with_envvar(
     c("SHAREPOINT_USERNAME" = NA),
-    with_mock("pointr:::is_interactive" = mock_interactive, {
-      expect_error(
-        get_single_credential("SHAREPOINT_USERNAME", "username", read_cred),
-        "'username' must be a character, either set env var SHAREPOINT_USERNAME or enter in interactive session"
-      )
-    })
-  )
+    expect_error(
+      get_single_credential("SHAREPOINT_USERNAME", "username", read_cred),
+      "'username' must be a character, either set env var SHAREPOINT_USERNAME or enter at prompt"
+    ))
 })


### PR DESCRIPTION
This PR lets us fetch credentials in a non-interactive session, which is needed for the orderly workflow.  Using `scan` seems to work in both interactive and not, and getPass always did (edit: `scan` did not work in interactive Rstudio sessions - now there is quite a big nocov block unfortunately)

Merge after #3 as this one builds on that PR