### PR TITLE
default download path and inherit file extension

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: 
     person(given = "Robert",
            family = "Ashton",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     getPass,
     glue,
     httr,
+    tools,
     xml2
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,7 @@
+# pointr 0.0.4
+
+* Added a `NEWS.md` file to track changes to the package.
+* In `sharepoint_download()` the default tempfile for `save_path` inherits the 
+  file extension from `sharepoint_path`.
+* Add a default tempfile for `save_path` argument of `pointr$download()`.
+  

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -50,7 +50,9 @@ pointr <- R6::R6Class(
     #' @param save_path Path to save downloaded data to
     #' @param verbose If TRUE then HTTP requests will print verbose output
     #' @return Path to saved data
-    download = function(sharepoint_path, save_path, verbose = FALSE) {
+    download = function(sharepoint_path,
+                        save_path = tempfile_inherit_ext(sharepoint_path),
+                        verbose = FALSE) {
       if (verbose) {
         opts <- httr::progress()
       } else {

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -12,13 +12,17 @@
 #' in a browser and click menu on the RHS of the file name which appears on
 #' hover -> Copy link and manually edit to get the file path. See vignette for
 #' more details.
-#' @param save_path Path to location you want to save the data
+#' @param save_path Path to location you want to save the data. The default
+#' save location is a tempfile with the same file extension as the downloaded
+#' file.
 #' @param verbose If TRUE then HTTP requests will print verbose output
 #'
 #' @return Path to downloaded data
+#'
 #' @export
 sharepoint_download <- function(sharepoint_url, sharepoint_path,
-                                save_path = tempfile(), verbose = FALSE) {
+                                save_path = tempfile_inherit_ext(sharepoint_path),
+                                verbose = FALSE) {
   pointr <- pointr$new(sharepoint_url)
   pointr$download(sharepoint_path, save_path, verbose)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,3 +52,7 @@ assert_nonmissing <- function(x, name = deparse(substitute(x))) {
 pointr_file <- function(...) {
   system.file(..., package = "pointr", mustWork = TRUE)
 }
+
+tempfile_inherit_ext <- function(file) {
+  tempfile(fileext = paste0(".", tools::file_ext(file)))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,7 +55,8 @@ pointr_file <- function(...) {
 
 tempfile_inherit_ext <- function(file) {
   ext <- tools::file_ext(file)
-  if(ext != "")
+  if (ext != "") {
     ext <- paste0(".", ext)
+  }
   tempfile(fileext = ext)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,5 +54,8 @@ pointr_file <- function(...) {
 }
 
 tempfile_inherit_ext <- function(file) {
-  tempfile(fileext = paste0(".", tools::file_ext(file)))
+  ext <- tools::file_ext(file)
+  if(ext != "")
+    ext <- paste0(".", ext)
+  tempfile(fileext = ext)
 }

--- a/tests/testthat/test-pointr.R
+++ b/tests/testthat/test-pointr.R
@@ -87,3 +87,23 @@ test_that("sharepoint_download errors on 404", {
 
   expect_false(file.exists(t))
 })
+
+test_that("sharepoint_download default save_path inherits file extension", {
+
+  ## TODO: this is a pretty poor test, but I don't know how to 'mock' download
+  ##       a file with an extension.
+
+  ## Mock out authentication steps
+  security_token_res <- readRDS("mocks/security_token_response.rds")
+  cookies_res <- readRDS("mocks/cookies_response.rds")
+  mock_post <- mockery::mock(security_token_res, cookies_res)
+
+  withr::with_envvar(
+    c("SHAREPOINT_USERNAME" = "user", "SHAREPOINT_PASS" = "pass"),
+    with_mock("httr::POST" = mock_post, {
+      download <- sharepoint_download("https://httpbin.org", "/json")
+    })
+  )
+
+  expect_equal(tools::file_ext(download), "" )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -24,10 +24,12 @@ test_that("asserts", {
                "'test' must be nonempty")
 })
 
-test_that("tempfile_inherit_ext" {
+test_that("tempfile_inherit_ext", {
 
   tmpf <- tempfile_inherit_ext("jibberish.wahoo")
-
   expect_equal(tools::file_ext(tmpf), "wahoo")
   expect_equal(dirname(tmpf), tempdir())
+
+  tmpf2 <- tempfile_inherit_ext("jibberish")
+  expect_equal(tools::file_ext(tmpf2), "")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -23,3 +23,11 @@ test_that("asserts", {
   expect_error(assert_scalar_character("", "test"),
                "'test' must be nonempty")
 })
+
+test_that("tempfile_inherit_ext" {
+
+  tmpf <- tempfile_inherit_ext("jibberish.wahoo")
+
+  expect_equal(tools::file_ext(tmpf), "wahoo")
+  expect_equal(dirname(tmpf), tempdir())
+})


### PR DESCRIPTION
This is a small feature suggestion:

* In `sharepoint_download()`, the tempfile default for the `save_path` argument inherits the file extension from the `sharepoint_path` argument.  The default becomes `sharepoint_download(..., save_path = tempfile_inherit_ext(sharepoint_path))`. This is helpful if I download a file and pass it to a reader function in R that parses the file extension.

* `pointr$download()` has a default argument `save_path = tempfile_inherit_ext()` for convenience, consistent with `sharepoint_download()`.

The utils function `tempfile_inherit_ext()` is tested. But I did not know how to download a 'mock' file with an extension, so the test for the `sharepoint_download()` is weak. I did not know how to write a test for the `pointr$download()` with default `save_path` argument.

I bumped the version to v0.0.4 and added a `NEWS.md`.