### PR TITLE
reside-159: Further download options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Robert", "Ashton", role = c("aut", "cre"),
                     email = "r.ashton@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# pointr 0.1.1
+
+* Downloading files can overwrite existing files (`overwrite = TRUE`) and can return raw bytes rather than files (`dest = raw()`) (reside-159)
+
+# pointr 0.1.0
+
+* New `sharepoint_folder` class for simple operations with files (download, upload, list)
+
 # pointr 0.0.4
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -12,19 +12,23 @@
 #' in a browser and click menu on the RHS of the file name which appears on
 #' hover -> Copy link and manually edit to get the file path. See vignette for
 #' more details.
-#' @param save_path Path to location you want to save the data. The default
+#'
+#' @param dest Path to location you want to save the data. The default
 #' save location is a tempfile with the same file extension as the downloaded
 #' file.
-#' @param verbose If TRUE then HTTP requests will print verbose output
+#'
+#' @param progress If \code{TRUE} then HTTP requests will print a progress bar
+#'
+#' @param overwrite if \code{TRUE} then the \code{dest} will be
+#'   ovewritten if it exists (otherwise it an error will be thrown)
 #'
 #' @return Path to downloaded data
 #'
 #' @export
-sharepoint_download <- function(sharepoint_url, sharepoint_path,
-                                save_path = tempfile_inherit_ext(sharepoint_path),
-                                verbose = FALSE) {
+sharepoint_download <- function(sharepoint_url, sharepoint_path, dest = NULL,
+                                progress = FALSE, overwrite = FALSE) {
   pointr <- pointr$new(sharepoint_url)
-  pointr$download(sharepoint_path, save_path, verbose)
+  pointr$download(sharepoint_path, dest, progress, overwrite)
 }
 
 #' Create sharepoint connection for downloading data.
@@ -47,14 +51,13 @@ pointr <- R6::R6Class(
     #' @description
     #' Download data from sharepoint
     #' @param sharepoint_path Path to the resource within sharepoint
-    #' @param save_path Path to save downloaded data to
+    #' @param dest Path to save downloaded data to
     #' @param progress Display a progress bar during download?
     #' @return Path to saved data
-    download = function(sharepoint_path,
-                        save_path = tempfile_inherit_ext(sharepoint_path),
-                        progress = FALSE) {
-      download(private$client, URLencode(sharepoint_path), save_path,
-               sharepoint_path, progress)
+    download = function(sharepoint_path, dest = NULL, progress = FALSE,
+                        overwrite = FALSE) {
+      download(private$client, URLencode(sharepoint_path), dest,
+               sharepoint_path, progress, overwrite)
     },
 
     #' @description

--- a/R/sharepoint_folder.R
+++ b/R/sharepoint_folder.R
@@ -97,15 +97,18 @@ sharepoint_folder <- R6::R6Class(
     #' @param path The name of the path to download, relative to this folder
     #' @param dest Path to save downloaded data to. If \code{NULL} then a
     #'   temporary file with the same file extension as \code{path} is used.
+    #'   If code{raw()} (or any other raw value) then the raw bytes will be
+    #'   returned.
     #' @param progress Display httr's progress bar?
-    download = function(path, dest = NULL, progress = FALSE) {
+    #' @param overwrite Overwrite the file if it exists?
+    download = function(path, dest = NULL, progress = FALSE,
+                        overwrite = FALSE) {
       url <- sprintf(
         "%s/Files('%s')/$value",
         sharepoint_folder_file_url(private$site, private$path, path),
         URLencode(basename(path)))
-      dest <- dest %||% tempfile_inherit_ext(path)
       path_show <- sprintf("%s:%s/%s", private$site, private$path, path)
-      download(private$client, url, dest, path_show, progress)
+      download(private$client, url, dest, path_show, progress, overwrite)
     },
 
     #' @description Upload a file into a folder

--- a/R/utils.R
+++ b/R/utils.R
@@ -111,3 +111,8 @@ download_dest <- function(dest, src) {
   }
   dest
 }
+
+
+`%||%` <- function(a, b) {
+  if (is.null(a)) b else a
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,9 +84,9 @@ to_time <- function(str) {
 
 
 download <- function(client, url, dest, path, progress, overwrite) {
+  dest <- download_dest(dest, path)
   opts <- if (progress) httr::progress() else NULL
   write <- if (is.raw(dest)) NULL else httr::write_disk(dest, overwrite)
-  dest <- download_dest(dest, path)
 
   r <- client$GET(url, opts, write)
   if (httr::status_code(r) == 404) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,14 +83,32 @@ to_time <- function(str) {
 }
 
 
-download <- function(client, url, dest, path, progress) {
+download <- function(client, url, dest, path, progress, overwrite) {
   opts <- if (progress) httr::progress() else NULL
-  r <- client$GET(url, opts, httr::write_disk(dest))
+  write <- if (is.raw(dest)) NULL else httr::write_disk(dest, overwrite)
+  dest <- download_dest(dest, path)
+
+  r <- client$GET(url, opts, write)
   if (httr::status_code(r) == 404) {
-    unlink(dest)
+    if (!is.raw(dest)) {
+      unlink(dest)
+    }
     stop(sprintf("Remote file not found at '%s'", path))
   }
   httr::stop_for_status(r)
+  if (is.raw(dest)) {
+    dest <- httr::content(r, "raw")
+  }
+  dest
+}
+
+
+download_dest <- function(dest, src) {
+  if (is.null(dest)) {
+    dest <- tempfile_inherit_ext(src)
+  } else if (!is.raw(dest)) {
+    assert_scalar_character(dest)
+  }
   dest
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -111,8 +111,3 @@ download_dest <- function(dest, src) {
   }
   dest
 }
-
-
-`%||%` <- function(a, b) {
-  if (is.null(a)) b else a
-}

--- a/man/pointr.Rd
+++ b/man/pointr.Rd
@@ -42,8 +42,9 @@ Download data from sharepoint
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{pointr$download(
   sharepoint_path,
-  save_path = tempfile_inherit_ext(sharepoint_path),
-  progress = FALSE
+  dest = NULL,
+  progress = FALSE,
+  overwrite = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -52,7 +53,7 @@ Download data from sharepoint
 \describe{
 \item{\code{sharepoint_path}}{Path to the resource within sharepoint}
 
-\item{\code{save_path}}{Path to save downloaded data to}
+\item{\code{dest}}{Path to save downloaded data to}
 
 \item{\code{progress}}{Display a progress bar during download?}
 }

--- a/man/sharepoint_download.Rd
+++ b/man/sharepoint_download.Rd
@@ -7,8 +7,9 @@
 sharepoint_download(
   sharepoint_url,
   sharepoint_path,
-  save_path = tempfile_inherit_ext(sharepoint_path),
-  verbose = FALSE
+  dest = NULL,
+  progress = FALSE,
+  overwrite = FALSE
 )
 }
 \arguments{
@@ -26,11 +27,14 @@ in a browser and click menu on the RHS of the file name which appears on
 hover -> Copy link and manually edit to get the file path. See vignette for
 more details.}
 
-\item{save_path}{Path to location you want to save the data. The default
+\item{dest}{Path to location you want to save the data. The default
 save location is a tempfile with the same file extension as the downloaded
 file.}
 
-\item{verbose}{If TRUE then HTTP requests will print verbose output}
+\item{progress}{If \code{TRUE} then HTTP requests will print a progress bar}
+
+\item{overwrite}{if \code{TRUE} then the \code{dest} will be
+ovewritten if it exists (otherwise it an error will be thrown)}
 }
 \value{
 Path to downloaded data

--- a/man/sharepoint_folder.Rd
+++ b/man/sharepoint_folder.Rd
@@ -96,7 +96,12 @@ Create an object referring to a child folder
 \subsection{Method \code{download()}}{
 Download a file from a folder
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{sharepoint_folder$download(path, dest = NULL, progress = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{sharepoint_folder$download(
+  path,
+  dest = NULL,
+  progress = FALSE,
+  overwrite = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -105,9 +110,13 @@ Download a file from a folder
 \item{\code{path}}{The name of the path to download, relative to this folder}
 
 \item{\code{dest}}{Path to save downloaded data to. If \code{NULL} then a
-temporary file with the same file extension as \code{path} is used.}
+temporary file with the same file extension as \code{path} is used.
+If code{raw()} (or any other raw value) then the raw bytes will be
+returned.}
 
 \item{\code{progress}}{Display httr's progress bar?}
+
+\item{\code{overwrite}}{Overwrite the file if it exists?}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/helper-sharepoint-client.R
+++ b/tests/testthat/helper-sharepoint-client.R
@@ -39,6 +39,12 @@ mock_response <- function(status_code = 200L) {
 }
 
 
+mock_download_client <- function() {
+  list(GET = function(url, ...)
+    httr::GET(paste0("https://httpbin.org", url), ...))
+}
+
+
 strip_url <- function(x) {
   gsub("https://[^/]+/sites/[^/]+/", "https://example.com/sites/mysite/", x)
 }

--- a/tests/testthat/test-pointr.R
+++ b/tests/testthat/test-pointr.R
@@ -88,7 +88,7 @@ test_that("sharepoint_download errors on 404", {
   expect_false(file.exists(t))
 })
 
-test_that("sharepoint_download default save_path inherits file extension", {
+test_that("sharepoint_download default dest inherits file extension", {
 
   ## Mock out authentication steps
   security_token_res <- readRDS("mocks/security_token_response.rds")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -55,6 +55,15 @@ test_that("Can download raw data", {
 })
 
 
+test_that("Can create a helpful temp name", {
+  client <- mock_download_client()
+  res <- download(client, "/gzip", NULL, "my.zip", FALSE, FALSE)
+  expect_is(res, "character")
+  expect_true(file.exists(res))
+  expect_match(res, "\\.zip$")
+})
+
+
 test_that("Can overwrite", {
   client <- mock_download_client()
   dest <- tempfile()

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -46,3 +46,31 @@ test_that("download filename validation", {
   expect_error(download_dest(NA_character_, "b.y"),
                "'dest' must not be NA")
 })
+
+
+test_that("Can download raw data", {
+  client <- mock_download_client()
+  res <- download(client, "/gzip", raw(), "my.zip", FALSE, FALSE)
+  expect_is(res, "raw")
+})
+
+
+test_that("Can overwrite", {
+  client <- mock_download_client()
+  dest <- tempfile()
+  file.create(dest)
+  res <- download(client, "/gzip", dest, "my.zip", FALSE, TRUE)
+  expect_true(file.size(dest) > 0)
+  expect_error(
+    download(client, "/gzip", dest, "my.zip", FALSE, FALSE))
+})
+
+
+test_that("Don't write file on 404", {
+  client <- mock_download_client()
+  dest <- tempfile()
+  expect_error(
+    download(client, "/status/404", dest, "my.zip", FALSE, FALSE),
+    "Remote file not found at 'my.zip'")
+  expect_false(file.exists(dest))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -33,3 +33,16 @@ test_that("tempfile_inherit_ext", {
   tmpf2 <- tempfile_inherit_ext("jibberish")
   expect_equal(tools::file_ext(tmpf2), "")
 })
+
+
+test_that("download filename validation", {
+  expect_equal(download_dest("a.x", "b.y"), "a.x")
+  expect_equal(download_dest(raw(), "b.y"), raw())
+  expect_match(download_dest(NULL, "b.y"), "\\.y$")
+  expect_error(download_dest(1, "b.y"),
+               "'dest' must be a character")
+  expect_error(download_dest(c("a", "b"), "b.y"),
+               "'dest' must be a scalar")
+  expect_error(download_dest(NA_character_, "b.y"),
+               "'dest' must not be NA")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,13 @@
 context("utils")
 
+test_that("null-or-value works", {
+  expect_equal(1 %||% NULL, 1)
+  expect_equal(1 %||% 2, 1)
+  expect_equal(NULL %||% NULL, NULL)
+  expect_equal(NULL %||% 2, 2)
+})
+
+
 test_that("clean input text", {
   expect_equal(clean_input_text('"foo"'), "foo") # strip quotes
   expect_equal(clean_input_text('  foo'), "foo") # strip leading whitespace


### PR DESCRIPTION
This PR adds two additional options to the downloading:

* Enables `overwrite` which is passed through to httr - this removes a confusing error message where the user is prompted to add this arg but it's not supported
* Enables `dest = raw()` to return raw bytes rather than a file - this is useful if the downloaded data is sensitive and to be encrypted

I've also continued harmonising argument names etc in the various places that downloads exist, and pushing more of the logic into the helper function, which is now more thoroughly tested separately from everything else