### PR TITLE
reside-155: Allow saving and restoring of auth data between sessions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Robert", "Ashton", role = c("aut", "cre"),
                     email = "r.ashton@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pointr 0.1.2
+
+* Allow caching of authentication data between sessions by saving cookies to disk (reside-155)
+
 # pointr 0.1.1
 
 * Downloading files can overwrite existing files (`overwrite = TRUE`) and can return raw bytes rather than files (`dest = raw()`) (reside-159)

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -40,14 +40,17 @@ pointr <- R6::R6Class(
 
   public = list(
     #' @description
+    #' A low-level sharepoint client object, which can be used to interact
+    #' directly with the sharepoint API.  This object mostly handles
+    #' authentication, etc.
+    client = NULL,
+
+    #' @description
     #' Create pointr object for downloading data from sharepoint
     #' @param sharepoint_url Root URL of sharepoint site to download from
     #' @return A new `pointr` object
     initialize = function(sharepoint_url, auth = NULL) {
-      if (is.character(auth)) {
-        auth <- read_binary(auth)
-      }
-      private$client <- sharepoint_client$new(sharepoint_url, auth)
+      self$client <- sharepoint_client$new(sharepoint_url, auth)
     },
 
     #' @description
@@ -58,7 +61,7 @@ pointr <- R6::R6Class(
     #' @return Path to saved data
     download = function(sharepoint_path, dest = NULL, progress = FALSE,
                         overwrite = FALSE) {
-      download(private$client, URLencode(sharepoint_path), dest,
+      download(self$client, URLencode(sharepoint_path), dest,
                sharepoint_path, progress, overwrite)
     },
 
@@ -77,32 +80,7 @@ pointr <- R6::R6Class(
     #' @param verify Logical, indicating if the site/path combination is
     #' valid (slower but safer).
     folder = function(site, path, verify = FALSE) {
-      sharepoint_folder$new(private$client, site, path, verify)
-    },
-
-    #' @description
-    #' Get the authentication data from the client.  If this is saved
-    #' to a file it provides a way of re-authenticating with a server
-    #' for a limited period (typically between a few days and a few
-    #' weeks) without re-entering the username and password, and may be
-    #' suitable for automated tasks.  Note that unlike proper OAuth-based
-    #' access, there is no way of revoking such access and so the
-    #' authentication data should be treated very carefully.
-    #'
-    #' @param file A file to write the data to. If \code{NULL} the raw data
-    #' is returned directly.
-    get_auth_data = function(file) {
-      dat <- private$client$get_auth_data()
-      if (is.null(file)) {
-        dat
-      } else {
-        writeBin(dat, file)
-        file
-      }
+      sharepoint_folder$new(self$client, site, path, verify)
     }
-  ),
-
-  private = list(
-    client = NULL
   )
 )

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -39,13 +39,15 @@ pointr <- R6::R6Class(
   cloneable = FALSE,
 
   public = list(
-
     #' @description
     #' Create pointr object for downloading data from sharepoint
     #' @param sharepoint_url Root URL of sharepoint site to download from
     #' @return A new `pointr` object
-    initialize = function(sharepoint_url) {
-      private$client <- sharepoint_client$new(sharepoint_url)
+    initialize = function(sharepoint_url, auth = NULL) {
+      if (is.character(auth)) {
+        auth <- read_binary(auth)
+      }
+      private$client <- sharepoint_client$new(sharepoint_url, auth)
     },
 
     #' @description
@@ -76,6 +78,27 @@ pointr <- R6::R6Class(
     #' valid (slower but safer).
     folder = function(site, path, verify = FALSE) {
       sharepoint_folder$new(private$client, site, path, verify)
+    },
+
+    #' @description
+    #' Get the authentication data from the client.  If this is saved
+    #' to a file it provides a way of re-authenticating with a server
+    #' for a limited period (typically between a few days and a few
+    #' weeks) without re-entering the username and password, and may be
+    #' suitable for automated tasks.  Note that unlike proper OAuth-based
+    #' access, there is no way of revoking such access and so the
+    #' authentication data should be treated very carefully.
+    #'
+    #' @param file A file to write the data to. If \code{NULL} the raw data
+    #' is returned directly.
+    get_auth_data = function(file) {
+      dat <- private$client$get_auth_data()
+      if (is.null(file)) {
+        dat
+      } else {
+        writeBin(dat, file)
+        file
+      }
     }
   ),
 

--- a/R/pointr.R
+++ b/R/pointr.R
@@ -39,7 +39,7 @@ pointr <- R6::R6Class(
   cloneable = FALSE,
 
   public = list(
-    #' @description
+    #' @field client
     #' A low-level sharepoint client object, which can be used to interact
     #' directly with the sharepoint API.  This object mostly handles
     #' authentication, etc.
@@ -48,6 +48,7 @@ pointr <- R6::R6Class(
     #' @description
     #' Create pointr object for downloading data from sharepoint
     #' @param sharepoint_url Root URL of sharepoint site to download from
+    #' @param auth Authentication data passed to the client
     #' @return A new `pointr` object
     initialize = function(sharepoint_url, auth = NULL) {
       self$client <- sharepoint_client$new(sharepoint_url, auth)
@@ -58,6 +59,7 @@ pointr <- R6::R6Class(
     #' @param sharepoint_path Path to the resource within sharepoint
     #' @param dest Path to save downloaded data to
     #' @param progress Display a progress bar during download?
+    #' @param overwrite Overwrite existing files?
     #' @return Path to saved data
     download = function(sharepoint_path, dest = NULL, progress = FALSE,
                         overwrite = FALSE) {

--- a/R/sharepoint_client.R
+++ b/R/sharepoint_client.R
@@ -24,47 +24,39 @@ sharepoint_client <- R6::R6Class(
     #' @return A new `sharepoint_client` object
     initialize = function(sharepoint_url, auth = NULL) {
       self$sharepoint_url <- sharepoint_url
-      self$login(auth)
+      private$handle <- httr::handle(self$sharepoint_url)
+      if (is.null(auth)) {
+        self$login()
+      } else {
+        self$set_auth_data(auth)
+      }
     },
 
-    #' @param auth Authentication data as returned by the
-    #' \code{$get_auth_data()} method
-    login = function(auth = NULL) {
-      private$handle <- httr::handle(self$sharepoint_url)
-      if (!is.null(auth)) {
-        stopifnot(is.raw(auth))
-        auth <- unserialize(auth)
-        ## construct manually because we can't escape this
-        cookies <- httr::config(cookie = paste(auth$name, auth$value,
-                                               sep = "=", collapse = "; "))
-        res <- self$POST("/_api/contextinfo", httr::accept_json(),
-                         cookies)
-        httr::stop_for_status(res)
-      } else {
-        creds <- get_credentials()
-        response <- httr::POST(
-          "https://login.microsoftonline.com/extSTS.srf",
-          body = prepare_security_token_payload(self$sharepoint_url, creds))
-        ## Not sure if this ever returns a non 200 response but left
-        ## here to be safe. On failed auth it sends a different set of
-        ## xml but still 200
-        if (response$status_code != 200) {
-          stop(sprintf("Failed to authenticate user '%s'.", creds$username))
-        }
-        ## Note that httr preserves cookies and settings over multiple
-        ## requests via the handle. Means that if we auth once and
-        ## retrieve cookies httr will automatically send these on
-        ## subsequent requests if using the same handle object
-        ##
-        ## These tokens last for ~24h
-        security_token <- parse_security_token_response(response)
-        if (is.na(security_token)) {
-          stop(sprintf("Failed to retrieve security token for user '%s'.",
-                       creds$username))
-        }
-        res <- self$POST("_forms/default.aspx?wa=wsignin1.0",
-                         body = security_token)
+    #' @description Login to sharepoint with username and password
+    login = function() {
+      creds <- get_credentials()
+      response <- httr::POST(
+        "https://login.microsoftonline.com/extSTS.srf",
+        body = prepare_security_token_payload(self$sharepoint_url, creds))
+      ## Not sure if this ever returns a non 200 response but left
+      ## here to be safe. On failed auth it sends a different set of
+      ## xml but still 200
+      if (response$status_code != 200) {
+        stop(sprintf("Failed to authenticate user '%s'.", creds$username))
       }
+      ## Note that httr preserves cookies and settings over multiple
+      ## requests via the handle. Means that if we auth once and
+      ## retrieve cookies httr will automatically send these on
+      ## subsequent requests if using the same handle object
+      ##
+      ## These tokens last for ~24h
+      security_token <- parse_security_token_response(response)
+      if (is.na(security_token)) {
+        stop(sprintf("Failed to retrieve security token for user '%s'.",
+                     creds$username))
+      }
+      res <- self$POST("_forms/default.aspx?wa=wsignin1.0",
+                       body = security_token)
       validate_cookies(res)
     },
 
@@ -114,13 +106,34 @@ sharepoint_client <- R6::R6Class(
     },
 
     #' @description
-    #' Return cached authentication information, \emph{without username and
-    #' password}, which can be used to authenticated again.
-    get_auth_data = function() {
+    #' Get the authentication data from the client.  If this is saved
+    #' to a file it provides a way of re-authenticating with a server
+    #' for a limited period (typically between a few days and a few
+    #' weeks) without re-entering the username and password, and may be
+    #' suitable for automated tasks.  Note that unlike proper OAuth-based
+    #' access, there is no way of revoking such access and so the
+    #' authentication data should be treated very carefully.
+    #'
+    #' @param file A file to write the data to. If \code{NULL} the raw data
+    #' is returned directly.
+    get_auth_data = function(file = NULL) {
       dat <- httr::cookies(private$handle)
-      serialize(
+      d <- serialize(
         dat[dat$name %in% c("rtFa", "FedAuth"), c("name", "value")],
         NULL)
+      if (is.null(file)) {
+        d
+      } else {
+        writeBin(d, file)
+        file
+      }
+    },
+
+    set_auth_data = function(auth) {
+      cookies <- auth_to_cookies(auth)
+      res <- self$POST("/_api/contextinfo", httr::accept_json(), cookies)
+      httr::stop_for_status(res)
+      validate_cookies(res)
     }
   ),
 
@@ -181,4 +194,16 @@ Must provide rtFa and FedAuth cookies, got %s",
                  paste(cookies$name, collapse = ", ")))
   }
   invisible(TRUE)
+}
+
+
+auth_to_cookies <- function(auth) {
+  if (is.character(auth)) {
+    stopifnot(file.exists(auth))
+    auth <- read_binary(auth)
+  }
+  stopifnot(is.raw(auth))
+  auth <- unserialize(auth)
+  string <- paste(auth$name, auth$value, sep = "=", collapse = "; ")
+  httr::config(cookie = string)
 }

--- a/R/sharepoint_folder.R
+++ b/R/sharepoint_folder.R
@@ -19,6 +19,7 @@ sharepoint_folder <- R6::R6Class(
 
   public = list(
     initialize = function(client, site, path, verify = FALSE) {
+      stopifnot(inherits(client, "sharepoint_client"))
       private$client <- client
       private$site <- site
       private$path <- path

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,3 +116,8 @@ download_dest <- function(dest, src) {
 `%||%` <- function(a, b) {
   if (is.null(a)) b else a
 }
+
+
+read_binary <- function(path) {
+  readBin(path, raw(), file.size(path))
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ Authenticates using pattern detailed https://paulryan.com.au/2014/spo-remote-aut
 There is a package exists on github for managing lists - not clear whether this will work with downloading any data as package doesn't work with most basic example of retrieveing all available lists
 https://github.com/LukasK13/sharepointr#list-all-available-lists
 
+## Authentication
+
+The authentication mechanism is subject to change.
+
+`pointr` will look for the environment variables `SHAREPOINT_USERNAME` and `SHAREPOINT_PASS` for your credentials and prompt interactively for any missing.
+
+Once authenticated you can save your authentication data to disk for future sessions with:
+
+```
+p$client$get_auth_data(".auth")
+```
+
+(for a pointr object `p` saving to a file `.auth`).  You can then use this by constructing your object as:
+
+```
+p <- pointr::pointr$new(..., auth = ".auth")
+```
+
+Be sure to add this file your `.gitignore` and treat it like a password.
+
 ## Testing
 
 Note there is no end-to-end test in this package that we can authenticate with a real sharepoint server and download data. Can run this manually to download a dataset which should be available to everyone with an Imperial login. Note that when prompted for a username it is name as you use it to login to imperial account e.g. `jbloggs@ic.ac.uk` opposed to your email `j.bloggs@imperial.ac.uk`

--- a/man/pointr.Rd
+++ b/man/pointr.Rd
@@ -8,6 +8,15 @@ Create sharepoint connection for downloading data.
 
 Create sharepoint connection for downloading data.
 }
+\section{Public fields}{
+\if{html}{\out{<div class="r6-fields">}}
+\describe{
+\item{\code{client}}{A low-level sharepoint client object, which can be used to interact
+directly with the sharepoint API.  This object mostly handles
+authentication, etc.}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
@@ -21,13 +30,15 @@ Create sharepoint connection for downloading data.
 \subsection{Method \code{new()}}{
 Create pointr object for downloading data from sharepoint
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{pointr$new(sharepoint_url)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{pointr$new(sharepoint_url, auth = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{sharepoint_url}}{Root URL of sharepoint site to download from}
+
+\item{\code{auth}}{Authentication data passed to the client}
 }
 \if{html}{\out{</div>}}
 }
@@ -56,6 +67,8 @@ Download data from sharepoint
 \item{\code{dest}}{Path to save downloaded data to}
 
 \item{\code{progress}}{Display a progress bar during download?}
+
+\item{\code{overwrite}}{Overwrite existing files?}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
This PR allows us to dump cookies and restore them later; this allows saving cookies to disk as a slightly less dangerous form of authentication data between sessions.

Unfortunately curl does not allow directly setting cookies in a handle, and the testing is even worse than usual.  However, it does work.