### PR TITLE
reside-160: Allow directory creation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^buildkite$
 ^docker$
 ^Makefile$
+^scripts$
+^docs$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Robert", "Ashton", role = c("aut", "cre"),
                     email = "r.ashton@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pointr 0.1.3
+
+* Support for creating folders (reside-160)
+
 # pointr 0.1.2
 
 * Allow caching of authentication data between sessions by saving cookies to disk (reside-155)

--- a/R/sharepoint_client.R
+++ b/R/sharepoint_client.R
@@ -75,9 +75,17 @@ sharepoint_client <- R6::R6Class(
     #'
     #' @param ... Args passed on to httr
     #'
+    #' @param digest Argument passed through to \code{$digest()} to create
+    #' the response digest; typically a site name
+    #'
     #' @return HTTP response
-    POST = function(...) {
-      self$request(httr::POST, ...)
+    POST = function(..., digest = NULL) {
+      if (!is.null(digest)) {
+        digest <- self$digest(digest)
+        self$request(httr::POST, ..., digest)
+      } else {
+        self$request(httr::POST, ...)
+      }
     },
 
     #' @description

--- a/man/sharepoint_folder.Rd
+++ b/man/sharepoint_folder.Rd
@@ -17,6 +17,7 @@ Interact with sharepoint folders and their files.
 \item \href{#method-list}{\code{sharepoint_folder$list()}}
 \item \href{#method-parent}{\code{sharepoint_folder$parent()}}
 \item \href{#method-folder}{\code{sharepoint_folder$folder()}}
+\item \href{#method-create}{\code{sharepoint_folder$create()}}
 \item \href{#method-download}{\code{sharepoint_folder$download()}}
 \item \href{#method-upload}{\code{sharepoint_folder$upload()}}
 }
@@ -87,6 +88,22 @@ Create an object referring to a child folder
 \item{\code{path}}{The name of the folder, relative to this folder}
 
 \item{\code{verify}}{Verify that the folder exists (which it must really here)}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-create"></a>}}
+\subsection{Method \code{create()}}{
+Create a folder on sharepoint
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{sharepoint_folder$create(path)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{path}}{Directory relative to this folder}
 }
 \if{html}{\out{</div>}}
 }

--- a/scripts/update_web.sh
+++ b/scripts/update_web.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+DOCS_DIR=docs
+VERSION=$(git rev-parse --short HEAD)
+REMOTE_URL=$(git config --get remote.origin.url)
+
+mkdir -p ${DOCS_DIR}
+rm -rf ${DOCS_DIR}/.git
+git init ${DOCS_DIR}
+git -C ${DOCS_DIR} checkout --orphan gh-pages
+git -C ${DOCS_DIR} add .
+git -C ${DOCS_DIR} commit --no-verify -m "Update docs for version ${VERSION}"
+git -C ${DOCS_DIR} remote add origin -m "gh-pages" ${REMOTE_URL}
+git -C ${DOCS_DIR} push --force -u origin gh-pages


### PR DESCRIPTION
This PR adds support for creating a directory as a subdirectory of a folder

Does not support recursive creation (so `$create("a/b/c")`) needs to be done in 3 goes.  Massive faff to get the right headers on here - this thew 400s at me until I went through the headers against the python client...