### PR TITLE
reside-161: Support for listing a subdirectory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pointr
 Title: Enables downloading of data from sharepoint
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Robert", "Ashton", role = c("aut", "cre"),
                     email = "r.ashton@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ LazyData: true
 Suggests: 
     mockery,
     testthat,
-    tibble,
+    tibble (>= 3.0.0),
     withr
 Imports: 
     getPass,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pointr 0.1.4
+
+* Support for listing subdirectories (reside-161)
+
 # pointr 0.1.3
 
 * Support for creating folders (reside-160)

--- a/R/sharepoint_folder.R
+++ b/R/sharepoint_folder.R
@@ -35,10 +35,10 @@ sharepoint_folder <- R6::R6Class(
     },
 
     #' @description List all files within the folder
-    files = function() {
+    files = function(path = NULL) {
       url <- sprintf(
         "/sites/%s/_api/web/GetFolderByServerRelativeURL('%s')/files",
-        private$site, URLencode(private$path))
+        private$site, URLencode(file_path2(private$path, path)))
       r <- private$client$GET(url)
       httr::stop_for_status(r)
       dat <- response_from_json(r)
@@ -52,10 +52,10 @@ sharepoint_folder <- R6::R6Class(
     },
 
     #' @description List all folders within the folder
-    folders = function() {
+    folders = function(path = NULL) {
       url <- sprintf(
         "/sites/%s/_api/web/GetFolderByServerRelativeURL('%s')/folders",
-        private$site, URLencode(private$path))
+        private$site, URLencode(file_path2(private$path, path)))
       r <- private$client$GET(url)
       httr::stop_for_status(r)
       dat <- response_from_json(r)
@@ -68,9 +68,9 @@ sharepoint_folder <- R6::R6Class(
 
     #' @description List all folders and files within the folder; this is a
     #' convenience wrapper around the \code{files} and \code{folders} methods.
-    list = function() {
-      folders <- self$folders()
-      files <- self$files()
+    list = function(path = NULL) {
+      folders <- self$folders(path)
+      files <- self$files(path)
       folders$size <- rep(NA_real_, nrow(folders))
       folders$is_folder <- TRUE
       files$items <- rep(NA_integer_, nrow(files))

--- a/R/utils.R
+++ b/R/utils.R
@@ -121,3 +121,8 @@ download_dest <- function(dest, src) {
 read_binary <- function(path) {
   readBin(path, raw(), file.size(path))
 }
+
+
+file_path2 <- function(a, b) {
+  if (is.null(b)) a else file.path(a, b)
+}

--- a/tests/testthat/test-sharepoint-folder.R
+++ b/tests/testthat/test-sharepoint-folder.R
@@ -6,12 +6,24 @@ test_that("list files", {
   expect_is(folder, "sharepoint_folder")
 
   folder_files_res <- readRDS("mocks/folder_files_response.rds")
-  mock_get <- mockery::mock(folder_files_res)
+  mock_get <- mockery::mock(folder_files_res, cycle = TRUE)
   dat <- with_mock("httr::GET" = mock_get,
                    folder$files())
   expect_is(dat, "tbl_df")
   expect_equal(names(dat), c("name", "size", "created", "modified"))
   expect_equal(dat$name, c("clipboard.txt", "test.txt"))
+
+  expect_identical(with_mock("httr::GET" = mock_get, folder$files("a/b/c")),
+                   dat)
+
+  expect_equal(
+    mockery::mock_args(mock_get)[[1]][[1]],
+    paste0("https://httpbin.org//sites/site/_api/web/",
+           "GetFolderByServerRelativeURL('path')/files"))
+  expect_equal(
+    mockery::mock_args(mock_get)[[2]][[1]],
+    paste0("https://httpbin.org//sites/site/_api/web/",
+           "GetFolderByServerRelativeURL('path/a/b/c')/files"))
 })
 
 
@@ -21,12 +33,24 @@ test_that("list folders", {
   expect_is(folder, "sharepoint_folder")
 
   folder_folder_res <- readRDS("mocks/folder_folders_response.rds")
-  mock_get <- mockery::mock(folder_folder_res)
+  mock_get <- mockery::mock(folder_folder_res, cycle = TRUE)
   dat <- with_mock("httr::GET" = mock_get,
                    folder$folders())
   expect_is(dat, "tbl_df")
   expect_equal(names(dat), c("name", "items", "created", "modified"))
   expect_equal(dat$name, c("data_offers", "administration_station"))
+
+  expect_identical(with_mock("httr::GET" = mock_get, folder$folders("a/b/c")),
+                   dat)
+
+  expect_equal(
+    mockery::mock_args(mock_get)[[1]][[1]],
+    paste0("https://httpbin.org//sites/site/_api/web/",
+           "GetFolderByServerRelativeURL('path')/folders"))
+  expect_equal(
+    mockery::mock_args(mock_get)[[2]][[1]],
+    paste0("https://httpbin.org//sites/site/_api/web/",
+           "GetFolderByServerRelativeURL('path/a/b/c')/folders"))
 })
 
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -91,3 +91,9 @@ test_that("Don't write file on 404", {
     "Remote file not found at 'my.zip'")
   expect_false(file.exists(dest))
 })
+
+
+test_that("file_path2", {
+  expect_equal(file_path2("a/b", NULL), "a/b")
+  expect_equal(file_path2("a/b", "c"), "a/b/c")
+})


### PR DESCRIPTION
This PR allows listing of a subdirectory, so that

```
folder$list("x")
```

works rather than having to do

```
folder$folder("x")$list()
```