### PR TITLE
reside-207: add integration tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spud
 Title: Sharepoint upload & download
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Robert", "Ashton", role = c("aut", "cre"),
                     email = "r.ashton@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# spud 0.1.7
+
+* Folders now expose a public readonly field `site` and `path` (reside-200)
+
 # spud 0.1.6
 
 * Add a delete method to folders (reside-205)

--- a/README.md
+++ b/README.md
@@ -56,3 +56,17 @@ sharepoint_download("https://imperiallondon.sharepoint.com", "Shared%20Documents
 * Error handling - do we want to do some better error handling here if any of the requests fail? e.g. particularly bad if downloading a resource which doesn't exist
 * Testing - look at httptest & vcr which might provide some slightly nicer testing atm we are relying heavily on mocks.
 * Vignette - write one!
+
+## Tests
+
+Most of the tests make heavy use of mocks, so if the API changes we might not catch breaking changes. In order to hedge against this we run a small number of integration tests against sharepoint. To opt into running these tests you need to define some environment variables:
+
+```
+SPUD_TEST_SHAREPOINT_USERNAME=you@example.com
+SPUD_TEST_SHAREPOINT_PASSWORD=s3cret!
+SPUD_TEST_SHAREPOINT_HOST=https://example.sharepoint.com
+SPUD_TEST_SHAREPOINT_SITE=yoursite
+SPUD_TEST_SHAREPOINT_ROOT=path/on/your/site
+```
+
+This will create a new directory on your sharepoint site below the path given at `SPUD_TEST_SHAREPOINT_ROOT`, one per time the test suite is run, and it will add, list, remove files that are there.

--- a/README.md
+++ b/README.md
@@ -38,25 +38,6 @@ Be sure to add this file your `.gitignore` and treat it like a password.
 
 If using multi-factor authentication then the above approach won't work. You need to generate an app password and enter this when prompted for your password. See [microsoft docs](https://docs.microsoft.com/en-gb/azure/active-directory/user-help/multi-factor-authentication-end-user-app-passwords) for details on how to generate an app password.
 
-## Testing
-
-Note there is no end-to-end test in this package that we can authenticate with a real sharepoint server and download data. Can run this manually to download a dataset which should be available to everyone with an Imperial login. Note that when prompted for a username it is name as you use it to login to imperial account e.g. `jbloggs@ic.ac.uk` opposed to your email `j.bloggs@imperial.ac.uk`
-
-```
-sharepoint_download("https://imperiallondon.sharepoint.com", "Shared%20Documents/Document.docx", tempfile(fileext = ".docx"))
-```
-
-### TODO
-
-* Caching for `sharepoint_download` function. Probably a kv store of sharepoint URL + user to `spud` or `sharepoint_client` object
-* Allow more formats of the resource URL - at the moment users need to do some manual formatting to put this into the correct formatting hopefully we can support
-   * Copy from url when previewing document
-   * The "copy link" button for a resource
-   * Manually building path from sites and the document list
-* Error handling - do we want to do some better error handling here if any of the requests fail? e.g. particularly bad if downloading a resource which doesn't exist
-* Testing - look at httptest & vcr which might provide some slightly nicer testing atm we are relying heavily on mocks.
-* Vignette - write one!
-
 ## Tests
 
 Most of the tests make heavy use of mocks, so if the API changes we might not catch breaking changes. In order to hedge against this we run a small number of integration tests against sharepoint. To opt into running these tests you need to define some environment variables:
@@ -70,3 +51,7 @@ SPUD_TEST_SHAREPOINT_ROOT=path/on/your/site
 ```
 
 This will create a new directory on your sharepoint site below the path given at `SPUD_TEST_SHAREPOINT_ROOT`, one per time the test suite is run, and it will add, list, remove files that are there.
+
+## License
+
+MIT © Imperial College of Science, Technology and Medicine

--- a/man/sharepoint_folder.Rd
+++ b/man/sharepoint_folder.Rd
@@ -8,6 +8,15 @@ Interact with sharepoint folders and their files.
 
 Interact with sharepoint folders and their files.
 }
+\section{Public fields}{
+\if{html}{\out{<div class="r6-fields">}}
+\describe{
+\item{\code{site}}{Name of the sharepoint site (readonly)}
+
+\item{\code{path}}{Path of the folder (readonly)}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{

--- a/tests/testthat/helper-sharepoint-client.R
+++ b/tests/testthat/helper-sharepoint-client.R
@@ -85,7 +85,7 @@ set_cookies <- function(handle, data) {
             handle = handle)
 }
 
-integration_test_client <- local({
+integration_test_client <- function() {
   v <- c("username", "password", "host", "site", "root")
   dat <- Sys.getenv(paste0("SPUD_TEST_SHAREPOINT_", toupper(v)), NA_character_)
 
@@ -105,7 +105,5 @@ integration_test_client <- local({
   tmp <- basename(tempfile("test_"))
   folder <- root$create(tmp)
 
-  function() {
-    list(folder = folder, client = client)
-  }
-})
+  list(folder = folder, client = client)
+}

--- a/tests/testthat/helper-sharepoint-client.R
+++ b/tests/testthat/helper-sharepoint-client.R
@@ -84,3 +84,28 @@ set_cookies <- function(handle, data) {
   httr::GET("https://httpbin.org/cookies/set", query = cookies,
             handle = handle)
 }
+
+integration_test_client <- local({
+  v <- c("username", "password", "host", "site", "root")
+  dat <- Sys.getenv(paste0("SPUD_TEST_SHAREPOINT_", toupper(v)), NA_character_)
+
+  if (any(is.na(dat))) {
+    testthat::skip(c(
+      "Environment variables not defined for integration tests:",
+      paste0(" - ", names(dat)[is.na(dat)])))
+  }
+  names(dat) <- v
+
+  ## This needs tidying up: RESIDE-162
+  client <- withr::with_envvar(c(
+    SHAREPOINT_USERNAME = dat[["username"]],
+    SHAREPOINT_PASS = dat[["password"]]),
+    sharepoint$new(dat[["host"]]))
+  root <- client$folder(dat[["site"]], dat[["root"]], verify = TRUE)
+  tmp <- basename(tempfile("test_"))
+  folder <- root$create(tmp)
+
+  function() {
+    list(folder = folder, client = client)
+  }
+})

--- a/tests/testthat/test-sharepoint-folder.R
+++ b/tests/testthat/test-sharepoint-folder.R
@@ -76,8 +76,8 @@ test_that("get parent directory", {
   p <- mock_sharepoint()
   folder <- p$folder("site", "a/b/c")
   parent <- folder$parent()
-  expect_equal(r6_private(parent)$path, "a/b")
-  expect_equal(r6_private(parent$parent()$parent())$path, ".")
+  expect_equal(parent$path, "a/b")
+  expect_equal(parent$parent()$parent()$path, ".")
 })
 
 
@@ -86,7 +86,7 @@ test_that("get child directory", {
   folder <- p$folder("site", "a")
   child <- folder$folder("b")$folder("c")
   expect_is(folder, "sharepoint_folder")
-  expect_equal(r6_private(child)$path, "a/b/c")
+  expect_equal(child$path, "a/b/c")
 })
 
 

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -1,0 +1,57 @@
+context("integration tests")
+
+test_that("Basic operations", {
+  folder <- integration_test_client()$folder
+  tmp <- basename(tempfile())
+  new <- folder$create(tmp)
+
+  expect_equal(basename(new$path), tmp)
+  expect_equal(new$parent()$path, folder$path)
+  expect_equal(
+    folder$list(tmp),
+    tibble::tibble(name = character(),
+                   items = numeric(),
+                   size = numeric(),
+                   is_folder = logical(),
+                   created = to_time(character()),
+                   modified = to_time(character())))
+
+  path_txt <- tempfile()
+  path_bin <- tempfile()
+  writeLines(letters, path_txt)
+  saveRDS(mtcars, path_bin)
+
+  new$upload(path_txt, "letters.txt", progress = FALSE)
+  new$upload(path_bin, "mtcars.rds", progress = FALSE)
+
+  contents <- new$files()
+  expect_equal(nrow(contents), 2)
+  expect_setequal(contents$name, c("letters.txt", "mtcars.rds"))
+  expect_equal(contents$size[contents$name == "mtcars.rds"],
+               file.size(path_bin))
+  expect_lt(contents$size[contents$name == "letters.txt"],
+            contents$size[contents$name == "mtcars.rds"])
+
+  ## Download text
+  p <- new$download("letters.txt")
+  expect_match(p, "\\.txt")
+  expect_true(file.exists(p))
+  expect_equal(normalizePath(dirname(p)), normalizePath(tempdir()))
+  expect_identical(readLines(p), letters)
+
+  ## Download binary
+  p <- tempfile()
+  expect_equal(new$download("mtcars.rds", p), p)
+  expect_identical(readRDS(p), mtcars)
+
+  contents <- folder$folders()
+  expect_true(tmp %in% contents$name)
+  i <- which(tmp == contents$name)
+  expect_equal(contents$items[[i]], 2)
+
+  expect_error(
+    folder$delete(tmp, "nothere"),
+    "The file 'nothere' was not found in the folder to delete '.+'")
+  folder$delete(tmp, "letters.txt")
+  expect_false(tmp %in% folder$folders()$name)
+})


### PR DESCRIPTION
Also sneaks a fix in for reside-200 as I wanted that for a test.

These are basic but span most of the functionality. You should be able to see the carnage on the reside sharepoint.

We could wire these up to run in buildkite, but for now at least we have something that runs locally. The buildkite bit will require some provisioning faff that I'd rather not to right now